### PR TITLE
Special Wildcards

### DIFF
--- a/app/Http/Route.php
+++ b/app/Http/Route.php
@@ -157,6 +157,8 @@ class Route
                 $regex .= "\/$part";
             } elseif ($part === '*') {
                 $regex .= '\/.*';
+            } elseif ($part === '**') {
+                $regex .= '\/(.*)';
             } else {
                 $regex .= "\/$part";
             }
@@ -184,6 +186,17 @@ class Route
     }
 
     /**
+     * Checks if the route contains a special
+     * double-star wildcard
+     *
+     * @return bool
+     */
+    private function containsDoubleWildcard(): bool
+    {
+        return (strpos($this->pattern, "**") !== false);
+    }
+
+    /**
      * Checks if the requested url
      * matches this route and additionally parses
      * all arguments and updates the request, iff vars are present
@@ -197,7 +210,7 @@ class Route
         $pattern = $this->getSanitizedPatternArray($this->pattern);
         $urlParts = $this->getSanitizedPatternArray($url);
 
-        if (count($pattern) !== count($urlParts)) {
+        if ((!$this->containsDoubleWildcard()) && (count($pattern) !== count($urlParts))) {
             return false;
         }
 

--- a/bootstrap/wildcards.php
+++ b/bootstrap/wildcards.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Http\Request;
+use App\Http\Response;
+use App\Quicky;
+
+$app = Quicky::create();
+Quicky::session()->start();
+
+Quicky::route("GET", "/start/*/end/", function (Request $_, Response $response) {
+    $response->send("Standard Wildcard matched!");
+});
+
+Quicky::route("GET", "/start/**/end", function (Request $_, Response $response) {
+    $response->send("Double Wildcard matched!");
+});


### PR DESCRIPTION
Allow multiple path parts in one wildcard:

Standard wildcard:
/start/*/end/ allows /start/abc/end/ but noch /start/abc/abc/end/

Special wildcard:
/start/**/end/ allows /start/abc/end/ and also /start/abc/abc/end/.
You may repeat the inner parts as often as you want. It is important that the route ends on "/end".